### PR TITLE
Update Playwright browser install step in CI workflow

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -29,8 +29,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Install Playwright browsers
-        uses: microsoft/playwright-github-action@v1
+      - name: Install Playwright browsers and system dependencies
+        run: npx playwright install --with-deps
 
       - name: Run tests
         env:


### PR DESCRIPTION
Replaces the Playwright GitHub Action with a direct 'npx playwright install --with-deps' command to install browsers and system dependencies during CI. This may improve compatibility and control over the installation process.